### PR TITLE
chore: use print syntax for github output

### DIFF
--- a/.github/workflows/check_request.yaml
+++ b/.github/workflows/check_request.yaml
@@ -11,7 +11,7 @@ permissions:
 
 # Use concurrency to ensure that only one instance of this workflow is running at a time
 concurrency:
-  group: pr-lint-checker
+  group: pr-lint-checker-${{ github.sha }}
   cancel-in-progress: true
 
 jobs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 name = "app-python"
 version = "0.0.1"
-authors = [{ name = "John Doe", email = "john.doe@whoknows.com" }]
+authors = [{ name = "Kristoffer Andersen", email = "john.doe@whoknows.com" }]
 
 
 [tool.ruff]


### PR DESCRIPTION
Testing another release. The previous failed. Assuming it was due to too restrictive branch protection policy